### PR TITLE
test offline data access with Firestore

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/FirebaseOfflineCacheTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/FirebaseOfflineCacheTest.java
@@ -1,0 +1,85 @@
+package ch.epfl.sdp;
+
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.SnapshotMetadata;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/*
+      Run tests in debug mode to see logs & values prints
+ */
+public class FirebaseOfflineCacheTest {
+
+    private static final String TAG = "OFFLINE CACHE TEST";
+    private FirebaseFirestore db = FirebaseFirestore.getInstance();
+    private String localChanges = "local changes";
+
+    @Rule
+    public final ActivityTestRule<FirebaseActivity> mActivityRule =
+            new ActivityTestRule<>(FirebaseActivity.class);
+    @Rule
+    public GrantPermissionRule internetPermissionRule =
+            GrantPermissionRule.grant(android.Manifest.permission.INTERNET);
+
+    @Before
+    public void setUp() {
+        String internetPermission = "android.permission.ACCESS_INTERNET";
+        if (ContextCompat.checkSelfPermission(mActivityRule.getActivity().getBaseContext(),
+                internetPermission) != PackageManager.PERMISSION_GRANTED) {
+            Log.e(TAG, "Aborting test -- not having internet permission!!!!");
+        }
+    }
+
+    /*
+    Modify the localChanges variable at each new run to convince yourself that it works
+     */
+    @Test
+    public void synchronizeLocalChangeWithBackendWhenBackOnline() {
+        db.disableNetwork()
+                .addOnCompleteListener(task -> System.out.println("NETWORK ACCESS IS DISABLED"));
+        // write operation to Firestore that is queued when offline
+        db.collection("Tests")
+                .document("LocalChangeSyncTest")
+                .update("locallyChangedValue", localChanges);
+        db.enableNetwork()
+                .addOnCompleteListener(task -> System.out.println("NETWORK ACCESS IS ENABLED"));
+        TestTools.sleep(5000);
+        // check changes on Firestore
+        db.collection("Tests")
+                .document("LocalChangeSyncTest").get()
+                .addOnSuccessListener(documentSnapshot ->
+                        System.out.println("SYNCHRONISE LOCAL/BACKEND: locallyChangedValue = " +
+                                documentSnapshot.get("locallyChangedValue")))
+                .addOnFailureListener(e ->
+                        Log.w(TAG, "Error retrieving locallyChangedValue from Firestore while online.", e));
+    }
+
+    @Test
+    public void readDataFromCacheWhenOffline() {
+        db.disableNetwork()
+                .addOnCompleteListener(task -> System.out.println("NETWORK ACCESS IS DISABLED"));
+        db.collection("Tests")
+                .document("LocalChangeSyncTest").get()
+                .addOnSuccessListener(documentSnapshot ->
+                        {
+                            SnapshotMetadata metadata = documentSnapshot.getMetadata();
+                            String source = metadata.isFromCache() ? "local cache" : "server";
+                            System.out.println("Data fetched from " + source);
+                            System.out.println("OFFLINE DATA: locallyChangedValue = " +
+                                    documentSnapshot.get("locallyChangedValue"));
+                        })
+                .addOnFailureListener(e ->
+                        Log.w(TAG, "Error retrieving locallyChangedValue from cache Firestore while offline.", e));
+        db.enableNetwork()
+                .addOnCompleteListener(task -> System.out.println("NETWORK ACCESS IS ENABLED"));
+    }
+}


### PR DESCRIPTION
Tests to check that :
- changes made locally in offline mode are then synchronized with Firestore backend server
- read are made from local cache when offline