### PR TITLE
change fixed SignInButton size to "math_parent"

### DIFF
--- a/app/src/main/res/layout/activity_authentication.xml
+++ b/app/src/main/res/layout/activity_authentication.xml
@@ -8,14 +8,15 @@
 
     <com.google.android.gms.common.SignInButton
         android:id="@+id/sign_in_button"
-        android:layout_width="127dp"
-        android:layout_height="44dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:clickable="true"
+        android:focusable="true"
         android:text="@string/sign_in"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:focusable="true" />
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+    <!--layout_width=127dp and layout_height=44dp-->


### PR DESCRIPTION
Size of the Google SignInButton now adapts to its auto translated text.