### PR TITLE
Feature/map focus button

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0' // Charts
 
-    implementation 'com.github.wangjiegulu:rfab:2.0.0' // RapidFloatingActionButton of history
+    implementation 'com.github.wangjiegulu:rfab:2.0.0' // RapidFloatingActionButton for showing paths
 
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'com.google.android.gms:play-services-auth:18.0.0'

--- a/app/src/androidTest/java/ch/epfl/sdp/map/fragment/MapActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/map/fragment/MapActivityTest.java
@@ -299,6 +299,8 @@ public class MapActivityTest {
 
         testMapVisible();
 
+        pathGetsInstantiated();
+
         clickToSeePath();
 
         double zoom_before = mapFragment.getMap().getCameraPosition().zoom;

--- a/app/src/main/java/ch/epfl/sdp/map/PathsHandler.java
+++ b/app/src/main/java/ch/epfl/sdp/map/PathsHandler.java
@@ -100,7 +100,6 @@ public class PathsHandler extends Fragment {
     private ConcreteDataReceiver concreteDataReceiver = new ConcreteDataReceiver(
             new GridFirestoreInteractor());
 
-
     public PathsHandler(@NonNull MapFragment parentClass, @NonNull MapboxMap map) {
         this.parentClass = parentClass;
         this.map = map;
@@ -134,6 +133,9 @@ public class PathsHandler extends Fragment {
         if (TEST_NON_EMPTY_LIST) {
             fakeInitialization();
             setLayers();
+            return;
+        }
+        if (TEST_EMPTY_PATH) {
             return;
         }
 
@@ -317,6 +319,9 @@ public class PathsHandler extends Fragment {
             }
         }
     }
+
+    @VisibleForTesting
+    public static boolean TEST_EMPTY_PATH;
 
     @VisibleForTesting
     public static boolean TEST_NON_EMPTY_LIST;

--- a/app/src/main/java/ch/epfl/sdp/map/PathsHandler.java
+++ b/app/src/main/java/ch/epfl/sdp/map/PathsHandler.java
@@ -3,7 +3,6 @@ package ch.epfl.sdp.map;
 import android.annotation.SuppressLint;
 import android.graphics.Color;
 import android.location.Location;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -197,11 +196,9 @@ public class PathsHandler extends Fragment {
     }
 
     public void seeWholePath(int day) {
-        Log.d("SEEWHOLEPATH: ", "enter method");
         LatLngBounds latLngBounds = day == R.string.yesterday ? yesterdayLLB : beforeLLB;
 
         if (map != null) {
-            Log.d("SEEWHOLEPATH: ", "new lat lng bounds");
             map.easeCamera(CameraUpdateFactory.newLatLngBounds(latLngBounds, 100), 2000);
         }
     }
@@ -209,14 +206,11 @@ public class PathsHandler extends Fragment {
     private LatLngBounds setLatLngBounds(int day) {
         List<Point> pathCoord = day == R.string.yesterday ? yesterdayPathCoordinates :
                 beforeYesterdayPathCoordinates;
-        Log.d("SETLATLNGBNDS: ", "pathCoord is empty? " + pathCoord.isEmpty());
         LatLngBounds.Builder boundsBuilder = new LatLngBounds.Builder();
-        double lat;
-        double lon;
+
         for (int i = 0; i<pathCoord.size(); ++i) {
-            Log.d("LATLNGBOUNDS INDEX: ", String.valueOf(i));
-            lat = pathCoord.get(i).latitude();
-            lon = pathCoord.get(i).longitude();
+            double lat = pathCoord.get(i).latitude();
+            double lon = pathCoord.get(i).longitude();
             boundsBuilder.include(new LatLng(lat, lon));
         }
         return boundsBuilder.build();
@@ -238,7 +232,6 @@ public class PathsHandler extends Fragment {
             latitudeYesterday = yesterdayPathCoordinates.get(0).latitude();
             longitudeYesterday = yesterdayPathCoordinates.get(0).longitude();
             yesterdayLLB = setLatLngBounds(R.string.yesterday);
-            Log.d("yesterdayLLB is empty: ", String.valueOf(yesterdayLLB.isEmptySpan()));
             pathLocationSet1 = true;
         }
         if (!beforeYesterdayPathCoordinates.isEmpty()) {

--- a/app/src/main/java/ch/epfl/sdp/map/PathsHandler.java
+++ b/app/src/main/java/ch/epfl/sdp/map/PathsHandler.java
@@ -3,6 +3,7 @@ package ch.epfl.sdp.map;
 import android.annotation.SuppressLint;
 import android.graphics.Color;
 import android.location.Location;
+import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -194,20 +195,24 @@ public class PathsHandler extends Fragment {
     }
 
     public void seeWholePath(int day) {
+        Log.d("SEEWHOLEPATH: ", "enter method");
         LatLngBounds latLngBounds = day == R.string.yesterday ? yesterdayLLB : beforeLLB;
 
         if (map != null) {
-            map.easeCamera(CameraUpdateFactory.newLatLngBounds(latLngBounds, 10), 2000);
+            Log.d("SEEWHOLEPATH: ", "new lat lng bounds");
+            map.easeCamera(CameraUpdateFactory.newLatLngBounds(latLngBounds, 100), 2000);
         }
     }
 
     private LatLngBounds setLatLngBounds(int day) {
         List<Point> pathCoord = day == R.string.yesterday ? yesterdayPathCoordinates :
                 beforeYesterdayPathCoordinates;
+        Log.d("SETLATLNGBNDS: ", "pathCoord is empty? " + pathCoord.isEmpty());
         LatLngBounds.Builder boundsBuilder = new LatLngBounds.Builder();
         double lat;
         double lon;
         for (int i = 0; i<pathCoord.size(); ++i) {
+            Log.d("LATLNGBOUNDS INDEX: ", String.valueOf(i));
             lat = pathCoord.get(i).latitude();
             lon = pathCoord.get(i).longitude();
             boundsBuilder.include(new LatLng(lat, lon));
@@ -231,6 +236,7 @@ public class PathsHandler extends Fragment {
             latitudeYesterday = yesterdayPathCoordinates.get(0).latitude();
             longitudeYesterday = yesterdayPathCoordinates.get(0).longitude();
             yesterdayLLB = setLatLngBounds(R.string.yesterday);
+            Log.d("yesterdayLLB is empty: ", String.valueOf(yesterdayLLB.isEmptySpan()));
             pathLocationSet1 = true;
         }
         if (!beforeYesterdayPathCoordinates.isEmpty()) {

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -10,7 +10,6 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -380,7 +379,6 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
 
     @Override
     public void onRFACItemIconClick(int position, RFACLabelItem item) {
-        String day = position == 0 ? getString(R.string.yesterday) : getString(R.string.before_yesterday);
         int dayInt = position == 0 ? R.string.yesterday : R.string.before_yesterday;
 
         togglePath(dayInt);

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -81,6 +81,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
     private MapFragment classPointer;
     private ServiceConnection conn;
     private Callable onMapVisible;
+    private int CURRENT_PATH;
 
     private RapidFloatingActionHelper rfabHelper;
 
@@ -289,7 +290,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
         if (view.getId() == R.id.heatMapToggle) {
             toggleHeatMap();
         } else if (view.getId() == R.id.wholePath) {
-            //seeWholePath();
+            pathsHandler.seeWholePath(CURRENT_PATH);
         }
     }
 
@@ -311,6 +312,14 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
                     // button to see whole current path: appear when pressing to see some path, disappearing when pressing again
                     if (!layerId.equals(HEATMAP_LAYER_ID) && View.INVISIBLE == view.findViewById(R.id.wholePath).getVisibility()) {
                         view.findViewById(R.id.wholePath).setVisibility(View.VISIBLE);
+                    }
+                    if (layerId.equals(YESTERDAY_PATH_LAYER_ID)) {
+                        CURRENT_PATH = R.string.yesterday;
+                    } else if (layerId.equals(BEFORE_PATH_LAYER_ID)) {
+                        CURRENT_PATH = R.string.before_yesterday;
+                    }
+                    if (!TESTING_MODE && !layerId.equals(HEATMAP_LAYER_ID)) {
+                        Toast.makeText(getContext(), "Click on the square to see the whole path", Toast.LENGTH_SHORT).show();
                     }
                 }
             }
@@ -368,9 +377,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
     public void onRFACItemIconClick(int position, RFACLabelItem item) {
         String day = position == 0 ? getString(R.string.yesterday) : getString(R.string.before_yesterday);
         int dayInt = position == 0 ? R.string.yesterday : R.string.before_yesterday;
-        if (!TESTING_MODE) {
-            Toast.makeText(getContext(), "Click on focus button : " + position + 1 + "to see whole" + day + "path.", Toast.LENGTH_SHORT).show();
-        }
+
         togglePath(dayInt);
 
         rfabHelper.toggleContent();

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -308,15 +308,11 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
             if (layer != null) {
                 if (VISIBLE.equals(layer.getVisibility().getValue())) {
                     layer.setProperties(visibility(NONE));
-                    if (!layerId.equals(HEATMAP_LAYER_ID) && View.VISIBLE == view.findViewById(R.id.wholePath).getVisibility()) {
-                        view.findViewById(R.id.wholePath).setVisibility(View.INVISIBLE);
-                    }
+                    showPathZoomOutButton(layerId, View.VISIBLE, View.INVISIBLE);
                 } else {
                     layer.setProperties(visibility(VISIBLE));
                     // button to see whole current path: appear when pressing to see some path, disappearing when pressing again
-                    if (!layerId.equals(HEATMAP_LAYER_ID) && View.INVISIBLE == view.findViewById(R.id.wholePath).getVisibility()) {
-                        view.findViewById(R.id.wholePath).setVisibility(View.VISIBLE);
-                    }
+                    showPathZoomOutButton(layerId, View.INVISIBLE, View.VISIBLE);
                     if (layerId.equals(YESTERDAY_PATH_LAYER_ID)) {
                         CURRENT_PATH = R.string.yesterday;
                     } else if (layerId.equals(BEFORE_PATH_LAYER_ID)) {
@@ -328,6 +324,12 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
                 }
             }
         });
+    }
+
+    private void showPathZoomOutButton(String layerId, int invisible, int visible) {
+        if (!layerId.equals(HEATMAP_LAYER_ID) && invisible == view.findViewById(R.id.wholePath).getVisibility()) {
+            view.findViewById(R.id.wholePath).setVisibility(visible);
+        }
     }
 
     private void togglePath(int day) {

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -10,6 +10,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -163,6 +164,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
 
 
         view.findViewById(R.id.heatMapToggle).setOnClickListener(this);
+        view.findViewById(R.id.wholePath).setOnClickListener(this);
         setHistoryRFAButton();
 
         return view;
@@ -289,7 +291,9 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
     public void onClick(View view) {
         if (view.getId() == R.id.heatMapToggle) {
             toggleHeatMap();
+            Log.d("HEATMAPCLICKED: ", "onClick MapFragment");
         } else if (view.getId() == R.id.wholePath) {
+            Log.d("SQUARECLICKED: ", "method onClick in MapFragment");
             pathsHandler.seeWholePath(CURRENT_PATH);
         }
     }

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -38,7 +38,6 @@ import com.wangjie.rapidfloatingactionbutton.contentimpl.labellist.RapidFloating
 
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.concurrent.Callable;
 
 import ch.epfl.sdp.BuildConfig;
@@ -48,13 +47,13 @@ import ch.epfl.sdp.location.LocationBroker;
 import ch.epfl.sdp.location.LocationService;
 import ch.epfl.sdp.map.HeatMapHandler;
 import ch.epfl.sdp.map.PathsHandler;
-import ch.epfl.sdp.toDelete.HistoryDialogFragment;
 
-import static ch.epfl.sdp.map.PathsHandler.BEFORE_PATH_LAYER_ID;
-import static ch.epfl.sdp.map.PathsHandler.BEFORE_INFECTED_LAYER_ID;
-import static ch.epfl.sdp.map.PathsHandler.YESTERDAY_PATH_LAYER_ID;
-import static ch.epfl.sdp.map.PathsHandler.YESTERDAY_INFECTED_LAYER_ID;
 import static ch.epfl.sdp.location.LocationBroker.Provider.GPS;
+import static ch.epfl.sdp.map.HeatMapHandler.HEATMAP_LAYER_ID;
+import static ch.epfl.sdp.map.PathsHandler.BEFORE_INFECTED_LAYER_ID;
+import static ch.epfl.sdp.map.PathsHandler.BEFORE_PATH_LAYER_ID;
+import static ch.epfl.sdp.map.PathsHandler.YESTERDAY_INFECTED_LAYER_ID;
+import static ch.epfl.sdp.map.PathsHandler.YESTERDAY_PATH_LAYER_ID;
 import static com.mapbox.mapboxsdk.style.layers.Property.NONE;
 import static com.mapbox.mapboxsdk.style.layers.Property.VISIBLE;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
@@ -93,16 +92,17 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
     @VisibleForTesting
     public void onLayerLoaded(Callable func, String layerId) {
         map.getStyle(style -> {
-            if (style.getLayer(layerId) != null){
+            if (style.getLayer(layerId) != null) {
                 callDataLoaded(func);
             }
         });
     }
 
-    private void callDataLoaded(Callable func){
+    private void callDataLoaded(Callable func) {
         try {
             func.call();
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
     }
 
     @Nullable
@@ -176,6 +176,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
             view.findViewById(R.id.mapFragment).setVisibility(View.VISIBLE);
             view.findViewById(R.id.heatMapToggle).setVisibility(View.VISIBLE);
             view.findViewById(R.id.heapMapLoadingSpinner).setVisibility(View.GONE);
+            view.findViewById(R.id.wholePath).setVisibility((View.INVISIBLE));
 
             callOnMapVisible();
         } else {
@@ -287,16 +288,13 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
     public void onClick(View view) {
         if (view.getId() == R.id.heatMapToggle) {
             toggleHeatMap();
+        } else if (view.getId() == R.id.wholePath) {
+            //seeWholePath();
         }
     }
 
-    private void onClickHistory() {
-        HistoryDialogFragment dialog = new HistoryDialogFragment(this);
-        dialog.show(getActivity().getSupportFragmentManager(), "history_dialog_fragment");
-    }
-
     private void toggleHeatMap() {
-        toggleLayer(HeatMapHandler.HEATMAP_LAYER_ID);
+        toggleLayer(HEATMAP_LAYER_ID);
     }
 
     private void toggleLayer(String layerId) {
@@ -305,8 +303,15 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
             if (layer != null) {
                 if (VISIBLE.equals(layer.getVisibility().getValue())) {
                     layer.setProperties(visibility(NONE));
+                    if (!layerId.equals(HEATMAP_LAYER_ID) && View.VISIBLE == view.findViewById(R.id.wholePath).getVisibility()) {
+                        view.findViewById(R.id.wholePath).setVisibility(View.INVISIBLE);
+                    }
                 } else {
                     layer.setProperties(visibility(VISIBLE));
+                    // button to see whole current path: appear when pressing to see some path, disappearing when pressing again
+                    if (!layerId.equals(HEATMAP_LAYER_ID) && View.INVISIBLE == view.findViewById(R.id.wholePath).getVisibility()) {
+                        view.findViewById(R.id.wholePath).setVisibility(View.VISIBLE);
+                    }
                 }
             }
         });
@@ -364,13 +369,12 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
         String day = position == 0 ? getString(R.string.yesterday) : getString(R.string.before_yesterday);
         int dayInt = position == 0 ? R.string.yesterday : R.string.before_yesterday;
         if (!TESTING_MODE) {
-            Toast.makeText(getContext(), "Toggle path from: " + day, Toast.LENGTH_SHORT).show();
+            Toast.makeText(getContext(), "Click on focus button : " + position + 1 + "to see whole" + day + "path.", Toast.LENGTH_SHORT).show();
         }
         togglePath(dayInt);
 
         rfabHelper.toggleContent();
     }
-
 
     private void callOnMapVisible() {
 

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -144,6 +144,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
 
         view.findViewById(R.id.mapFragment).setVisibility(View.INVISIBLE);
         view.findViewById(R.id.heatMapToggle).setVisibility(View.GONE);
+        view.findViewById(R.id.wholePath).setVisibility((View.INVISIBLE));
 
         mapView = view.findViewById(R.id.mapFragment);
         mapView.onCreate(savedInstanceState);
@@ -179,7 +180,6 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
             view.findViewById(R.id.mapFragment).setVisibility(View.VISIBLE);
             view.findViewById(R.id.heatMapToggle).setVisibility(View.VISIBLE);
             view.findViewById(R.id.heapMapLoadingSpinner).setVisibility(View.GONE);
-            view.findViewById(R.id.wholePath).setVisibility((View.INVISIBLE));
 
             callOnMapVisible();
         } else {
@@ -311,12 +311,13 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
                     showPathZoomOutButton(layerId, View.VISIBLE, View.INVISIBLE);
                 } else {
                     layer.setProperties(visibility(VISIBLE));
-                    // button to see whole current path: appear when pressing to see some path, disappearing when pressing again
-                    showPathZoomOutButton(layerId, View.INVISIBLE, View.VISIBLE);
                     if (layerId.equals(YESTERDAY_PATH_LAYER_ID)) {
                         CURRENT_PATH = R.string.yesterday;
                     } else if (layerId.equals(BEFORE_PATH_LAYER_ID)) {
                         CURRENT_PATH = R.string.before_yesterday;
+                    }
+                    if (!layerId.equals(HEATMAP_LAYER_ID)) {
+                        showPathZoomOutButton(layerId, View.INVISIBLE, View.VISIBLE);
                     }
                     if (!TESTING_MODE && !layerId.equals(HEATMAP_LAYER_ID)) {
                         Toast.makeText(getContext(), "Click on the square to see the whole path", Toast.LENGTH_SHORT).show();
@@ -326,9 +327,9 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
         });
     }
 
-    private void showPathZoomOutButton(String layerId, int invisible, int visible) {
-        if (!layerId.equals(HEATMAP_LAYER_ID) && invisible == view.findViewById(R.id.wholePath).getVisibility()) {
-            view.findViewById(R.id.wholePath).setVisibility(visible);
+    private void showPathZoomOutButton(String layerId, int visibilityCheck, int buttonVisibility) {
+        if (!layerId.equals(HEATMAP_LAYER_ID) && visibilityCheck == view.findViewById(R.id.wholePath).getVisibility()) {
+            view.findViewById(R.id.wholePath).setVisibility(buttonVisibility);
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/map/fragment/MapFragment.java
@@ -291,9 +291,7 @@ public class MapFragment extends Fragment implements LocationListener, View.OnCl
     public void onClick(View view) {
         if (view.getId() == R.id.heatMapToggle) {
             toggleHeatMap();
-            Log.d("HEATMAPCLICKED: ", "onClick MapFragment");
         } else if (view.getId() == R.id.wholePath) {
-            Log.d("SQUARECLICKED: ", "method onClick in MapFragment");
             pathsHandler.seeWholePath(CURRENT_PATH);
         }
     }

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -17,6 +17,17 @@
         android:focusable="true"
         app:srcCompat="@android:drawable/ic_menu_view" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/wholePath"
+        app:fabSize="mini"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|start"
+        android:layout_margin="@dimen/baseMargin"
+        android:clickable="true"
+        mapbox:srcCompat="@drawable/marker"
+        android:focusable="true" />
+
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapFragment"
         android:layout_width="match_parent"
@@ -66,6 +77,7 @@
             mapbox:rfab_shadow_dy="0dp"
             mapbox:rfab_shadow_radius="1dp"
             mapbox:rfab_size="normal" />
+
     </com.wangjie.rapidfloatingactionbutton.RapidFloatingActionLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This feature adds the possibility to zoom out when seeing a path (yesterday/before yesterday) on the map. You click on the path you want to see, this makes the camera of the map focus on the first coordinates of the path. A new small button (square) appears on the top left: if you click on it, the map's camera adjusts itself so that you can see the path (the one you just clicked on) in its entirety.